### PR TITLE
update example with non empty puppeteer launch param

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ puppeteer.use(require('puppeteer-extra-plugin-angular')());
     theEmail: 'you@address.com',
   };
 
-  const browser = await puppeteer.launch();
+  const browser = await puppeteer.launch({});
   const page = await browser.newPage();
 
   // Calling page.waitUntilActionReady internally.


### PR DESCRIPTION
Calling empty puppeteer-extra launch with no param causes `TypeError: Cannot convert undefined or null to object`. Adding empty object avoid that issues.